### PR TITLE
fix: remove duplicate scm and distributionManagement injection

### DIFF
--- a/.github/workflows/publish-archetype.yml
+++ b/.github/workflows/publish-archetype.yml
@@ -65,23 +65,6 @@ jobs:
               content = f.read()
 
           dist = """
-            <distributionManagement>
-              <snapshotRepository>
-                <id>central</id>
-                <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
-              </snapshotRepository>
-              <repository>
-                <id>central</id>
-                <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-              </repository>
-            </distributionManagement>
-
-            <scm>
-              <connection>scm:git:git://github.com/Umutayb/test-automation-template.git</connection>
-              <developerConnection>scm:git:ssh://github.com/Umutayb/test-automation-template.git</developerConnection>
-              <url>https://github.com/Umutayb/test-automation-template</url>
-            </scm>
-
             <developers>
               <developer>
                 <id>umutayb</id>

--- a/.github/workflows/publish-archetype.yml
+++ b/.github/workflows/publish-archetype.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Locate generated archetype
         run: |
-          ARCHETYPE_DIR=$(find . -name "archetype-metadata.xml" | head -1 | xargs dirname | xargs dirname)
+          ARCHETYPE_DIR=$(find . -path "*/generated-sources/archetype" -type d | head -1)
           echo "ARCHETYPE_DIR=$ARCHETYPE_DIR" >> $GITHUB_ENV
           echo "Found archetype at: $ARCHETYPE_DIR"
 


### PR DESCRIPTION
The archetype pom inherits scm and distributionManagement from the project pom, so re-injecting them caused a 'Duplicated tag' error on deploy. Only inject developers and licenses now.