### PR TITLE
fix: inject plugins into existing build element

### DIFF
--- a/.github/workflows/publish-archetype.yml
+++ b/.github/workflows/publish-archetype.yml
@@ -137,11 +137,12 @@ jobs:
 
           # Inject developers/licenses before </project>
           content = content.replace("</project>", dist + "\n</project>")
-          # Inject publishing plugins into existing <build><plugins> section
-          if "</plugins>" in content:
-              content = content.replace("</plugins>", plugins + "\n    </plugins>", 1)
+          # Inject publishing plugins into existing <build> by adding <plugins> before </build>
+          plugins_block = "    <plugins>\n" + plugins + "\n    </plugins>\n"
+          if "</build>" in content:
+              content = content.replace("</build>", plugins_block + "  </build>", 1)
           else:
-              content = content.replace("</project>", "  <build>\n    <plugins>\n" + plugins + "\n    </plugins>\n  </build>\n</project>")
+              content = content.replace("</project>", "  <build>\n" + plugins_block + "  </build>\n</project>")
           with open("pom.xml", "w") as f:
               f.write(content)
           print("pom.xml updated")

--- a/.github/workflows/publish-archetype.yml
+++ b/.github/workflows/publish-archetype.yml
@@ -65,23 +65,6 @@ jobs:
               content = f.read()
 
           dist = """
-            <distributionManagement>
-              <snapshotRepository>
-                <id>central</id>
-                <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
-              </snapshotRepository>
-              <repository>
-                <id>central</id>
-                <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-              </repository>
-            </distributionManagement>
-
-            <scm>
-              <connection>scm:git:git://github.com/Umutayb/test-automation-template.git</connection>
-              <developerConnection>scm:git:ssh://github.com/Umutayb/test-automation-template.git</developerConnection>
-              <url>https://github.com/Umutayb/test-automation-template</url>
-            </scm>
-
             <developers>
               <developer>
                 <id>umutayb</id>

--- a/.github/workflows/publish-archetype.yml
+++ b/.github/workflows/publish-archetype.yml
@@ -135,7 +135,13 @@ jobs:
                 </plugin>
           """
 
-          content = content.replace("</project>", dist + "\n  <build>\n    <plugins>\n" + plugins + "\n    </plugins>\n  </build>\n</project>")
+          # Inject developers/licenses before </project>
+          content = content.replace("</project>", dist + "\n</project>")
+          # Inject publishing plugins into existing <build><plugins> section
+          if "</plugins>" in content:
+              content = content.replace("</plugins>", plugins + "\n    </plugins>", 1)
+          else:
+              content = content.replace("</project>", "  <build>\n    <plugins>\n" + plugins + "\n    </plugins>\n  </build>\n</project>")
           with open("pom.xml", "w") as f:
               f.write(content)
           print("pom.xml updated")

--- a/.github/workflows/publish-archetype.yml
+++ b/.github/workflows/publish-archetype.yml
@@ -65,6 +65,8 @@ jobs:
               content = f.read()
 
           dist = """
+            <description>Maven archetype for quickstarting Pickleib-based test automation projects with Cucumber, Selenium and Wasapi.</description>
+
             <developers>
               <developer>
                 <id>umutayb</id>

--- a/.github/workflows/publish-archetype.yml
+++ b/.github/workflows/publish-archetype.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Locate generated archetype
         run: |
-          ARCHETYPE_DIR=$(find . -name "archetype-metadata.xml" | head -1 | xargs dirname | xargs dirname)
+          ARCHETYPE_DIR=$(find . -path "*/generated-sources/archetype" -type d | head -1)
           echo "ARCHETYPE_DIR=$ARCHETYPE_DIR" >> $GITHUB_ENV
           echo "Found archetype at: $ARCHETYPE_DIR"
 


### PR DESCRIPTION
Previous attempt added a new build block when the archetype pom had no top-level plugins section. Now always injects into the existing build, adding a plugins child before /build close tag.